### PR TITLE
Adds device and system relative timestamps to imageFrame types

### DIFF
--- a/src/kinect_azure.cc
+++ b/src/kinect_azure.cc
@@ -486,6 +486,8 @@ Napi::Value MethodStartListening(const Napi::CallbackInfo& info) {
         colorImageFrame.Set(Napi::String::New(env, "width"), Napi::Number::New(env, jsFrame.colorImageFrame.width));
         colorImageFrame.Set(Napi::String::New(env, "height"), Napi::Number::New(env, jsFrame.colorImageFrame.height));
         colorImageFrame.Set(Napi::String::New(env, "strideBytes"), Napi::Number::New(env, jsFrame.colorImageFrame.stride_bytes));
+        colorImageFrame.Set(Napi::String::New(env, "deviceTimestamp"), Napi::Number::New(env, jsFrame.colorImageFrame.device_timestamp));
+        colorImageFrame.Set(Napi::String::New(env, "systemTimestamp"), Napi::Number::New(env, jsFrame.colorImageFrame.system_timestamp));
         data.Set(Napi::String::New(env, "colorImageFrame"), colorImageFrame);
       }
       {
@@ -496,6 +498,8 @@ Napi::Value MethodStartListening(const Napi::CallbackInfo& info) {
         depthImageFrame.Set(Napi::String::New(env, "width"), Napi::Number::New(env, jsFrame.depthImageFrame.width));
         depthImageFrame.Set(Napi::String::New(env, "height"), Napi::Number::New(env, jsFrame.depthImageFrame.height));
         depthImageFrame.Set(Napi::String::New(env, "strideBytes"), Napi::Number::New(env, jsFrame.depthImageFrame.stride_bytes));
+        depthImageFrame.Set(Napi::String::New(env, "deviceTimestamp"), Napi::Number::New(env, jsFrame.depthImageFrame.device_timestamp));
+        depthImageFrame.Set(Napi::String::New(env, "systemTimestamp"), Napi::Number::New(env, jsFrame.depthImageFrame.system_timestamp));
         data.Set(Napi::String::New(env, "depthImageFrame"), depthImageFrame);
       }
       {
@@ -506,6 +510,8 @@ Napi::Value MethodStartListening(const Napi::CallbackInfo& info) {
         irImageFrame.Set(Napi::String::New(env, "width"), Napi::Number::New(env, jsFrame.irImageFrame.width));
         irImageFrame.Set(Napi::String::New(env, "height"), Napi::Number::New(env, jsFrame.irImageFrame.height));
         irImageFrame.Set(Napi::String::New(env, "strideBytes"), Napi::Number::New(env, jsFrame.irImageFrame.stride_bytes));
+        irImageFrame.Set(Napi::String::New(env, "deviceTimestamp"), Napi::Number::New(env, jsFrame.irImageFrame.device_timestamp));
+        irImageFrame.Set(Napi::String::New(env, "systemTimestamp"), Napi::Number::New(env, jsFrame.irImageFrame.system_timestamp));
         data.Set(Napi::String::New(env, "irImageFrame"), irImageFrame);
       }
       {
@@ -673,6 +679,8 @@ Napi::Value MethodStartListening(const Napi::CallbackInfo& info) {
             jsFrame.depthImageFrame.height = k4a_image_get_height_pixels(depth_image);
             jsFrame.depthImageFrame.stride_bytes = k4a_image_get_stride_bytes(depth_image);
             jsFrame.depthImageFrame.image_data = new uint8_t[jsFrame.depthImageFrame.image_length];
+            jsFrame.depthImageFrame.device_timestamp = k4a_image_get_device_timestamp_usec(depth_image);
+          jsFrame.depthImageFrame.system_timestamp = k4a_image_get_system_timestamp_nsec(depth_image);
           }
         }
         // capture the IR image
@@ -684,6 +692,8 @@ Napi::Value MethodStartListening(const Napi::CallbackInfo& info) {
           jsFrame.irImageFrame.height = k4a_image_get_height_pixels(ir_image);
           jsFrame.irImageFrame.stride_bytes = k4a_image_get_stride_bytes(ir_image);
           jsFrame.irImageFrame.image_data = new uint8_t[jsFrame.irImageFrame.image_length];
+          jsFrame.irImageFrame.device_timestamp = k4a_image_get_device_timestamp_usec(ir_image);
+          jsFrame.irImageFrame.system_timestamp = k4a_image_get_system_timestamp_nsec(ir_image);
         }
       }
       if (g_deviceConfig.color_resolution != K4A_COLOR_RESOLUTION_OFF)
@@ -697,6 +707,8 @@ Napi::Value MethodStartListening(const Napi::CallbackInfo& info) {
           jsFrame.colorImageFrame.height = k4a_image_get_height_pixels(color_image);
           jsFrame.colorImageFrame.stride_bytes = k4a_image_get_stride_bytes(color_image);
           jsFrame.colorImageFrame.image_data = new uint8_t[jsFrame.colorImageFrame.image_length];
+          jsFrame.colorImageFrame.device_timestamp = k4a_image_get_device_timestamp_usec(color_image);
+          jsFrame.colorImageFrame.system_timestamp = k4a_image_get_system_timestamp_nsec(color_image);
         }
         colorTimestamp = (double)k4a_image_get_device_timestamp_usec(color_image);
       }

--- a/src/structs.h
+++ b/src/structs.h
@@ -8,6 +8,8 @@ typedef struct _JSImageFrame
 	int stride_bytes = 0;
 	int width = 0;
 	int height = 0;
+	uint64_t device_timestamp = NULL;
+	uint64_t system_timestamp = NULL;
 	void reset() {
 		if (image_data != NULL) {
 			delete [] image_data;
@@ -17,6 +19,8 @@ typedef struct _JSImageFrame
 		stride_bytes = 0;
 		width = 0;
 		height = 0;
+		device_timestamp = NULL;
+		system_timestamp = NULL;
 	}
 } JSImageFrame;
 


### PR DESCRIPTION
Modifies src/kinect_azure.cc to support colorImageFrame, depthImageFrame, and irImageFrame getting two new variables per image handle type:
- deviceTimestamp which is populated by k4a_image_get_device_timestamp_usec()
- systemTimestamp which is populated by k4a_image_get_system_timestamp_nsec()

Modifies src/structs.h to support these two new variables as uint64_t to match their native source

Usage matches the rest of jsFrame / data patterns

This approach is preferred to the singular kinect.time() method which only returned k4a_image_get_device_timestamp_usec(color_image) whereas now each frame's individual timestamp can be accessed